### PR TITLE
Upgrade lxml + black to clear CVEs (raise Python floor to 3.10)

### DIFF
--- a/.github/workflows/check_dependencies_poetry.yml
+++ b/.github/workflows/check_dependencies_poetry.yml
@@ -1,0 +1,41 @@
+name: check-dependencies-poetry
+
+# Validates a Poetry dependency bump before a human merges it. `poetry install`
+# resolves + installs the versions pinned in pyproject.toml on the repo's Python
+# (using poetry.lock when the repo commits one, else resolving from scratch), so a
+# version change is proven, not assumed. security-agent injects this when the repo
+# has no such workflow.
+
+on:
+  pull_request:
+    paths:
+      - "**/pyproject.toml"
+      - "**/poetry.lock"
+      - ".github/workflows/check_dependencies_poetry.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  poetry-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.10"
+      - name: Free disk space
+        # Heavy deps (numpy/scipy/torch/CUDA wheels) can exceed the runner's ~14 GB.
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
+          df -h /
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install dependencies
+        # Resolves + installs the pinned deps (uses poetry.lock if present, else resolves),
+        # proving the bumped versions install on this Python. --no-root skips building the project.
+        run: poetry install --no-root --no-interaction

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,27 +9,25 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: ["3.10", "3.11"]
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y curl
+        sudo apt-get install -y libgl1-mesa-glx libxrender1 libxext6
     - name: Install poetry
-      run: |
-        curl -sSL https://install.python-poetry.org | python3 -
-        echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+      run: pip install poetry
     - name: Setup
       run: make setup
     - name: Test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,19 +6,19 @@ authors = ["neka-nat <nekanat.stock@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.10"
 numpy = "^1.18.0"
 scipy = "^1.5.0"
 transformations = "^2020.1.1"
 absl-py = "^0.11.0"
-lxml = "^4.6.2"
+lxml = "==6.1.1"
 PyYAML = "^5.4.1"
 vtk = "^9.0.1"
 
 [tool.poetry.dev-dependencies]
 twine = "^3.3.0"
 isort = "^5.9.3"
-black = "^24.3.0"
+black = "==26.5.1"
 flake8 = "^5.0.4"
 flake8-bugbear = "^22.8.23"
 flake8-simplify = "^0.19.3"


### PR DESCRIPTION
## Security remediation: kinpy

Clears both open Dependabot alerts on this fork in one PR.

### Fixes
- **lxml `^4.6.2` → `==6.1.1`** — XXE via default `iterparse()` / `ETCompatXMLParser()` (**CVE-2026-41066**, GHSA-vfmq-68hx-4jfw). First fixed in **6.1.0**, so a 4.x pin has no in-major fix — this is an upgrade-or-stay-vulnerable **forced major**.
  - **Validation — non-breaking.** kinpy uses lxml only via `from lxml import etree` with `Element`/`SubElement`/`Comment`/`PI`/`tostring`/`strip_elements` and `parse`/`fromstring` (in `kinpy/mjcf_parser/*` and `kinpy/urdf_parser_py/xml_reflection/*`) — no `lxml.html`/`Cleaner`, no custom entity-resolution APIs. The 4.9→6.1 changelog documents no breaking changes to those core APIs; the 6.1.0 change is the security fix itself (external-entity resolution now defaults off). The repo parses its own local MJCF/URDF, so it should not depend on external entity expansion.
- **black `^24.3.0` → `==26.5.1`** — arbitrary file write via unsanitized `--python-cell-magics` in a cache filename (**CVE-2026-32274**, GHSA-3936-cmfr-pm3m), first fixed in 26.3.1. Dev-only formatter (`[tool.poetry.dev-dependencies]`), not imported by runtime code — non-breaking beyond formatting-style diffs.

### Python floor: `^3.7` → `^3.10`
black 26.x requires Python ≥3.10 (and lxml 6.x requires ≥3.8), so the floor must rise. **This breaks no consumer:** no RebootMotion repo declares a dependency on this fork (checked git-URL deps + submodules org-wide); the kinpy code that actually runs is **vendored inside `kinpy-proof-of-concept`, already on Python 3.11**.

### CI
The fork's `ubuntu.yml` was stale (dead `ubuntu-18.04` runner, `3.7/3.8` matrix, broken poetry install path) — modernized to `ubuntu-22.04` + `3.10/3.11`. Added a `check-dependencies-poetry` workflow that runs `poetry install --no-root` on 3.10 to prove the pins resolve + install.

Exact-pinned per our supply-chain standard; both targets are past the 7-day cooldown and advisory-clean.
